### PR TITLE
handle url-encoded DIDs in serve-plc

### DIFF
--- a/src/serve-plc.ts
+++ b/src/serve-plc.ts
@@ -7,7 +7,7 @@ if (!statement) throw new Error("can't serve plc when ZPLC_NO_RAW_LOG is set");
 
 export default {
   fetch(req, _info): Response {
-    const pathname = new URL(req.url).pathname;
+    const pathname = decodeURIComponent(new URL(req.url).pathname);
 
     if (pathname.startsWith("/did:")) {
       const did = pathname.substring(1);


### PR DESCRIPTION
figured I'd upstream this if you want, turns out the bsky appview sends url-encoded dids and express decodes them by default